### PR TITLE
use AutoHashEquals.jl

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,10 +1,11 @@
 name = "PolynomialBases"
 uuid = "c74db56a-226d-5e98-8bb0-a6049094aeea"
 author = ["Hendrik Ranocha"]
-version = "0.4.15-pre"
+version = "0.4.15"
 
 [deps]
 ArgCheck = "dce04be8-c92d-5529-be00-80e4d2c0e197"
+AutoHashEquals = "15f4f7f2-30c1-5605-9d31-71845cf9641f"
 FFTW = "7a1cc6ca-52ef-59f5-83cd-3a7055c09341"
 FastGaussQuadrature = "442a2c76-b920-505d-bb47-c5924d526838"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
@@ -14,6 +15,7 @@ UnPack = "3a884ed6-31ef-47d7-9d2a-63182c4928ed"
 
 [compat]
 ArgCheck = "2.0"
+AutoHashEquals = "0.2"
 FFTW = "1"
 FastGaussQuadrature = "0.4.2, 0.5"
 Requires = "1"

--- a/src/PolynomialBases.jl
+++ b/src/PolynomialBases.jl
@@ -3,6 +3,7 @@ module PolynomialBases
 using LinearAlgebra
 
 using ArgCheck: @argcheck
+using AutoHashEquals: @auto_hash_equals
 using FFTW: FFTW
 using FastGaussQuadrature: FastGaussQuadrature, gausslegendre, gausslobatto, gaussjacobi
 using Requires: @require

--- a/src/nodal_bases.jl
+++ b/src/nodal_bases.jl
@@ -137,7 +137,7 @@ Base.broadcastable(basis::NodalBasis) = Ref(basis)
 The nodal basis corresponding to Legendre Gauss Lobatto quadrature in [-1,1]
 with scalar type `T`.
 """
-struct LobattoLegendre{T} <: NodalBasis{Line}
+@auto_hash_equals struct LobattoLegendre{T} <: NodalBasis{Line}
     nodes::Vector{T}
     weights::Vector{T}
     baryweights::Vector{T}
@@ -194,7 +194,7 @@ end
 The nodal basis corresponding to Legendre Gauss quadrature in [-1,1]
 with scalar type `T`.
 """
-struct GaussLegendre{T} <: NodalBasis{Line}
+@auto_hash_equals struct GaussLegendre{T} <: NodalBasis{Line}
     nodes::Vector{T}
     weights::Vector{T}
     baryweights::Vector{T}
@@ -249,7 +249,7 @@ end
 The nodal basis corresponding to Jacobi Gauss quadrature in [-1,1]
 with parameters `α`, `β` and scalar type `T`.
 """
-struct GaussJacobi{T1<:Real, T<:Real} <: NodalBasis{Line}
+@auto_hash_equals struct GaussJacobi{T1<:Real, T<:Real} <: NodalBasis{Line}
     α::T1
     β::T1
     nodes::Vector{T}
@@ -304,7 +304,7 @@ end
 The nodal basis corresponding to the closed Newton Cotes quadrature in [-1,1]
 with scalar type `T`.
 """
-struct ClosedNewtonCotes{T} <: NodalBasis{Line}
+@auto_hash_equals struct ClosedNewtonCotes{T} <: NodalBasis{Line}
     nodes::Vector{T}
     weights::Vector{T}
     baryweights::Vector{T}
@@ -361,7 +361,7 @@ end
 The nodal basis corresponding to the Clenshaw Curtis quadrature in [-1,1] with
 scalar type `T`.
 """
-struct ClenshawCurtis{T} <: NodalBasis{Line}
+@auto_hash_equals struct ClenshawCurtis{T} <: NodalBasis{Line}
     nodes::Vector{T}
     weights::Vector{T}
     baryweights::Vector{T}

--- a/test/utilities_test.jl
+++ b/test/utilities_test.jl
@@ -7,6 +7,7 @@ for basis_type in subtypes(PolynomialBases.NodalBasis{PolynomialBases.Line})
         basis = basis_type(p, T)
         @inferred basis_type(p, T)
         @test eltype(basis.nodes) == T
+        @test basis == basis_type(p, T)
         u = ufunc.(basis.nodes)
         D, M, R, B, MinvRtB = utility_matrices(basis)
 


### PR DESCRIPTION
Before, the nodal bases used the general fallback `===` of `==`, so that bases with the same content are not necessarily `==`. 